### PR TITLE
Error fix when font size is empty

### DIFF
--- a/scripts/auto_font_size.js
+++ b/scripts/auto_font_size.js
@@ -55,7 +55,7 @@ angular.module('AutoFontSize', [])
                         function fontSizeI() {
                             var fontSize = css(inner, 'font-size');
                             var match = fontSize.match(/\d+/);
-                            if (match==null) {return;}
+                            if (!match) {return;}
                             return Number(fontSize.match(/\d+/)[0]);
                         }
                     

--- a/scripts/auto_font_size.js
+++ b/scripts/auto_font_size.js
@@ -56,7 +56,7 @@ angular.module('AutoFontSize', [])
                             var fontSize = css(inner, 'font-size');
                             var match = fontSize.match(/\d+/);
                             if (!match) {return;}
-                            return Number(fontSize.match(/\d+/)[0]);
+                            return Number(match[0]);
                         }
                     
                         function setFontSize(size) {

--- a/scripts/auto_font_size.js
+++ b/scripts/auto_font_size.js
@@ -54,6 +54,8 @@ angular.module('AutoFontSize', [])
                         
                         function fontSizeI() {
                             var fontSize = css(inner, 'font-size');
+                            var match = fontSize.match(/\d+/);
+                            if (match==null) {return;}
                             return Number(fontSize.match(/\d+/)[0]);
                         }
                     


### PR DESCRIPTION
Sometimes the font size is "" (empty space) and it causes an array index error
